### PR TITLE
chore(ci): CI/CD 워크플로우 브랜치 및 Node 버전 전략 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - "feature/**"
 
 jobs:
   build:
@@ -13,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 23.x]
+        node-version: [22.x]
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
- feature/** 브랜치에 대한 워크플로우 트리거 제거
- CI 빌드 전략에서 Node 23.x 지원 제거, 22.x만 유지