### PR TITLE
feat(login): 로그인 폼 및 API 연동 개선

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -11,8 +11,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "이메일과 비밀번호를 모두 입력하세요." }, { status: 400 });
     }
 
-    const user = await signInWithEmail(email, password);
-    return NextResponse.json({ success: true, uid: user.uid, email: user.email });
+    await signInWithEmail(email, password);
+
+    return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ success: false, error: (error as Error).message }, { status: 401 });
   }

--- a/src/components/src/login/page.tsx
+++ b/src/components/src/login/page.tsx
@@ -2,18 +2,47 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append("email", email);
+    formData.append("password", password);
+    try {
+      const response = await fetch("api/login", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await response.json();
+      if (data.success) {
+        router.push("/");
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
   return (
     <main className="grid place-items-center min-h-screen bg-gray-100">
       <div className="w-full place-items-center flex-col">
         <h1 className="text-4xl text-center">NextToDo</h1>
-        <div className="grid w-full max-w-sm items-center gap-3 mt-10">
+        <form
+          className="grid w-full max-w-sm items-center gap-3 mt-10"
+          onSubmit={handleSubmit}
+        >
           <Label htmlFor="username">Username</Label>
           <Input
             type="username"
             id="username"
             placeholder="enter username"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             className="bg-white h-10"
           />
           <Label htmlFor="password">Password</Label>
@@ -21,6 +50,8 @@ export default function Login() {
             type="password"
             id="password"
             placeholder="enter password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
             className="bg-white h-10"
           />
           <Button
@@ -33,10 +64,11 @@ export default function Login() {
           <Button
             variant={"outline"}
             className="w-full h-10 bg-green-500 text-white"
+            type="submit"
           >
             Sign Up
           </Button>
-        </div>
+        </form>
       </div>
     </main>
   );


### PR DESCRIPTION
- 로그인 폼에서 이메일/비밀번호 입력값을 상태로 관리하고, 제출 시 api/login 엔드포인트에 POST 요청하도록 변경
- 로그인 성공 시 useRouter의 router.push("/")로 메인 페이지로 이동
- api/login/route.ts에서 로그인 성공 시 success: true만 반환하도록 응답 구조 단순화