### PR TITLE
feat(register): 회원가입 후 메인 페이지로 리다이렉트 및 로그인 버튼 클릭 시 로그인 페이지로 이동 기능 추가

### DIFF
--- a/src/components/src/register/page.tsx
+++ b/src/components/src/register/page.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { signUpWithEmail } from "@/lib/backend/auth-actions";
 import { getRandomProfileImage } from "@/lib/profile-images";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 export default function Register() {
@@ -17,7 +18,7 @@ export default function Register() {
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-
+  const router = useRouter();
   useEffect(() => {
     // 클라이언트 사이드에서만 랜덤 이미지 선택
     setProfileImageURL(getRandomProfileImage().src);
@@ -58,7 +59,9 @@ export default function Register() {
     }
 
     try {
-      signUpWithEmail({ email, password, username, imageUrl });
+      signUpWithEmail({ email, password, username, imageUrl }).then(() => {
+        router.push("/");
+      });
     } catch (error) {
       console.error(error);
       console.log("회원가입 실패");
@@ -128,6 +131,7 @@ export default function Register() {
           <Button
             variant={"outline"}
             className="w-full h-10 bg-blue-500 text-white"
+            onClick={() => router.push("/login")}
           >
             Log In
           </Button>

--- a/src/lib/backend/auth-actions.ts
+++ b/src/lib/backend/auth-actions.ts
@@ -36,6 +36,7 @@ export async function signUpWithEmail(formData: SignUpForm) {
     // 3. Firestore의 'users' 컬렉션에 사용자 데이터 저장은 별도의 API Route에서 처리
     // 회원가입 성공 후 idToken을 받아 API Route로 전송
     const idToken = await user.getIdToken();
+    document.cookie = `firebase-token=${idToken}; path=/; max-age=86400`;
     await fetch('/api/user', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
- 회원가입 성공 시 useRouter의 router.push("/")로 메인 페이지로 이동하도록 변경
- 회원가입 페이지에서 로그인 버튼 클릭 시 router.push("/login")으로 로그인 페이지로 이동하도록 추가
- auth-actions.ts에서 회원가입 시 idToken을 쿠키에 저장하는 로직 추가