### PR TITLE
refactor(main): 유저/친구 타입 구조 개선 및 컴포넌트 타입 명확화

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -5,6 +5,13 @@ import {
   getUserFriendsFromList,
 } from "@/lib/backend/read-firebase";
 import HomeClient from "@/components/src/main/HomeClient";
+import { UserWithId } from "@/lib/backend/write-firebase";
+
+export interface friendsProps {
+  id: string;
+  name: string;
+  profileImage: string | null;
+}
 
 export default async function Home() {
   const cookieStore = await cookies();
@@ -25,7 +32,7 @@ export default async function Home() {
     name: userData.name ?? "나",
     profileImage: userData.profileImage ?? null,
     friendsList: friendUids,
-  };
+  } as UserWithId;
 
   return <HomeClient user={user} friends={friends} initialTasks={tasks} />;
 }

--- a/src/app/api/todo/[uid]/route.ts
+++ b/src/app/api/todo/[uid]/route.ts
@@ -3,12 +3,20 @@ import { NextResponse } from "next/server";
 
 export async function GET(request:Request, { params }: { params: Promise<{ uid: string }> }) {
   try {
-    const {uid} = await params
-    const todolists = await getUserTodoListByUid(uid);
+    // 1. Authorization 헤더에서 idToken 추출
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return NextResponse.json({ error: "인증 토큰이 필요합니다." }, { status: 401 });
+    }
+    const idToken = authHeader.split(" ")[1];
+
+    // 2. getUserTodoListByUid에 idToken과 uid 전달
+    const { uid } = await params;
+    const todolists = await getUserTodoListByUid(idToken, uid);
     return NextResponse.json(todolists);
   } catch (error) {
     const message = (error as Error).message;
-    if (message.includes("로그인")) {
+    if (message.includes("인증") || message.includes("로그인")) {
       return NextResponse.json({ error: message }, { status: 401 });
     }
     if (message.includes("친구가 아닌")) {

--- a/src/components/src/friends/FriendSearchResults.tsx
+++ b/src/components/src/friends/FriendSearchResults.tsx
@@ -29,7 +29,7 @@ export default function FriendSearchResults({
     (user) =>
       user.uid !== currentUserUid &&
       !currentFriends.includes(user.uid) &&
-      !hidden.includes(user.uid),
+      !hidden.includes(user.uid)
   );
 
   const handleAdd = (uid: string) => {
@@ -39,7 +39,9 @@ export default function FriendSearchResults({
 
   if (visibleResults.length === 0) {
     return (
-      <p className="text-center text-sm text-muted-foreground">추가할 수 있는 사용자가 없습니다.</p>
+      <p className="text-center text-sm text-muted-foreground">
+        추가할 수 있는 사용자가 없습니다.
+      </p>
     );
   }
 

--- a/src/components/src/main/FriendsList.tsx
+++ b/src/components/src/main/FriendsList.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { getRandomProfileImage } from "@/lib/profile-images";
+import { friendsProps } from "@/app/(main)/page";
 
 interface FriendListProps {
-  user: { id: string; name: string; profileImage: string | null };
-  friends: { id: string; name: string; profileImage: string | null }[];
+  user: friendsProps;
+  friends: friendsProps[];
   className?: string;
 }
 
@@ -16,15 +17,25 @@ export function FriendList({ user, friends, className }: FriendListProps) {
     <ScrollArea className={className ? className : "w-full whitespace-nowrap"}>
       <div className="flex w-max gap-4 p-4">
         {/* 본인 먼저 */}
-        <figure key={`user-${user.id}`} className="shrink-0 w-[80px] flex flex-col justify-center">
+        <figure
+          key={`user-${user.id}`}
+          className="shrink-0 w-[80px] flex flex-col justify-center"
+        >
           <div className="overflow-hidden rounded-md">
             <Avatar className="size-20">
-              <AvatarImage src={user.profileImage || getRandomProfileImage().src} alt={user.name} />
-              <AvatarFallback>{user.name.substring(0, 2).toUpperCase()}</AvatarFallback>
+              <AvatarImage
+                src={user.profileImage || getRandomProfileImage().src}
+                alt={user.name}
+              />
+              <AvatarFallback>
+                {user.name.substring(0, 2).toUpperCase()}
+              </AvatarFallback>
             </Avatar>
           </div>
           <figcaption className="text-foreground pt-2 text-xs text-center">
-            {user.name.length < NAME_LENGTH ? user.name : user.name.substring(0, 8) + "..."}
+            {user.name.length < NAME_LENGTH
+              ? user.name
+              : user.name.substring(0, 8) + "..."}
           </figcaption>
         </figure>
 
@@ -40,11 +51,15 @@ export function FriendList({ user, friends, className }: FriendListProps) {
                   src={friend.profileImage || getRandomProfileImage().src}
                   alt={friend.name}
                 />
-                <AvatarFallback>{friend.name.substring(0, 2).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>
+                  {friend.name.substring(0, 2).toUpperCase()}
+                </AvatarFallback>
               </Avatar>
             </div>
             <figcaption className="text-foreground pt-2 text-xs text-center">
-              {friend.name.length < NAME_LENGTH ? friend.name : friend.name.substring(0, 8) + "..."}
+              {friend.name.length < NAME_LENGTH
+                ? friend.name
+                : friend.name.substring(0, 8) + "..."}
             </figcaption>
           </figure>
         ))}

--- a/src/components/src/main/HomeClient.tsx
+++ b/src/components/src/main/HomeClient.tsx
@@ -3,10 +3,22 @@
 import { useFriendSearch } from "@/contexts/FriendSearchContext";
 import FriendSearchResults from "@/components/src/friends/FriendSearchResults";
 import { FriendList } from "@/components/src/main/FriendsList";
-import ToDoListsDashboard from "@/components/src/main/ToDoDashboad";
+import ToDoListsDashboard, { Task } from "@/components/src/main/ToDoDashboad";
 import LogOut from "@/components/src/main/LogOutButton";
+import { UserWithId } from "@/lib/backend/write-firebase";
+import { friendsProps } from "@/app/(main)/page";
 
-export default function HomeClient({ initialTasks, user, friends }) {
+interface HomeClientProps {
+  initialTasks: Task[];
+  user: UserWithId;
+  friends: friendsProps[];
+}
+
+export default function HomeClient({
+  initialTasks,
+  user,
+  friends,
+}: HomeClientProps) {
   const { keyword, results } = useFriendSearch();
 
   const handleAddFriend = async (uid: string) => {

--- a/src/lib/backend/write-firebase.ts
+++ b/src/lib/backend/write-firebase.ts
@@ -2,12 +2,13 @@ import adminDb, { adminAuth } from './firebase-admin';
 import { FieldValue } from 'firebase-admin/firestore';
 
 // 유저 프로필 데이터 타입 (예시)
-interface UserData {
+export interface UserData {
   email: string;
   name: string;
-  profileImage: string;
+  profileImage: string | null;
   friendsList: string[];
 }
+export type UserWithId = UserData & { id: string };
 
 // 할 일(Task) 데이터 타입 (예시)
 interface Task {


### PR DESCRIPTION
- UserData, UserWithId 타입을 write-firebase.ts에 정의 및 export
- friendsProps 타입을 (main)/page.tsx에 정의하여 FriendsList, HomeClient 등에서 재사용
- HomeClient, FriendsList 등 주요 컴포넌트에 props 타입 명확히 지정
- UserWithId 타입을 as 키워드로 적용하여 타입 안정성 강화
- FriendSearchResults, FriendsList 등 코드 스타일 및 가독성 개선
- profileImage 타입을 string | null로 변경하여 null 안전성 확보