### PR TITLE
refactor(types): export interface/type 공통화 및 타입 import 구조 개선

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -5,7 +5,7 @@ import {
   getUserFriendsFromList,
 } from "@/lib/backend/read-firebase";
 import HomeClient from "@/components/src/main/HomeClient";
-import { UserWithId } from "@/lib/backend/write-firebase";
+import { UserWithId } from "@/lib/type/interface";
 
 export interface friendsProps {
   id: string;

--- a/src/components/src/main/HomeClient.tsx
+++ b/src/components/src/main/HomeClient.tsx
@@ -3,10 +3,10 @@
 import { useFriendSearch } from "@/contexts/FriendSearchContext";
 import FriendSearchResults from "@/components/src/friends/FriendSearchResults";
 import { FriendList } from "@/components/src/main/FriendsList";
-import ToDoListsDashboard, { Task } from "@/components/src/main/ToDoDashboad";
+import ToDoListsDashboard from "@/components/src/main/ToDoDashboad";
 import LogOut from "@/components/src/main/LogOutButton";
-import { UserWithId } from "@/lib/backend/write-firebase";
 import { friendsProps } from "@/app/(main)/page";
+import { Task, UserWithId } from "@/lib/type/interface";
 
 interface HomeClientProps {
   initialTasks: Task[];

--- a/src/components/src/main/ToDoDashboad.tsx
+++ b/src/components/src/main/ToDoDashboad.tsx
@@ -22,13 +22,7 @@ import {
 } from "@/components/ui/context-menu";
 import { toast } from "sonner";
 import { auth } from "@/lib/backend/firebase";
-
-export interface Task {
-  id: string;
-  title: string;
-  isComplete: boolean;
-  createdAt: string;
-}
+import { Task } from "@/lib/type/interface";
 
 export default function ToDoListsDashboard({
   initialTasks,

--- a/src/components/src/main/ToDoTask.tsx
+++ b/src/components/src/main/ToDoTask.tsx
@@ -1,5 +1,5 @@
 import { Checkbox } from "@/components/ui/checkbox";
-import { Task } from "./ToDoDashboad";
+import { Task } from "@/lib/type/interface";
 
 export default function ToDoTask({
   task,

--- a/src/lib/backend/write-firebase.ts
+++ b/src/lib/backend/write-firebase.ts
@@ -1,14 +1,8 @@
+import { UserData } from '../type/interface';
 import adminDb, { adminAuth } from './firebase-admin';
 import { FieldValue } from 'firebase-admin/firestore';
 
-// 유저 프로필 데이터 타입 (예시)
-export interface UserData {
-  email: string;
-  name: string;
-  profileImage: string | null;
-  friendsList: string[];
-}
-export type UserWithId = UserData & { id: string };
+
 
 // 할 일(Task) 데이터 타입 (예시)
 interface Task {

--- a/src/lib/type/interface.ts
+++ b/src/lib/type/interface.ts
@@ -1,0 +1,25 @@
+// 모든 export interface를 한 곳에 모아 export
+
+// src/lib/backend/write-firebase.ts
+export interface UserData {
+  email: string;
+  name: string;
+  profileImage: string | null;
+  friendsList: string[];
+}
+export type UserWithId = UserData & { id: string };
+
+
+// src/app/(main)/page.tsx
+export interface friendsProps {
+  id: string;
+  name: string;
+  profileImage: string | null;
+} 
+
+export interface Task {
+    id: string;
+    title: string;
+    isComplete: boolean;
+    createdAt: string;
+  }


### PR DESCRIPTION
- UserData, UserWithId, Task, friendsProps 등 export interface/type을 src/lib/type/interface.ts로 통합
- 각 컴포넌트 및 백엔드 코드에서 공통 타입을 import하여 일관성 및 재사용성 향상
- ToDoDashboad, ToDoTask 등에서 Task 타입 import 경로를 interface.ts로 변경
- 기존 개별 파일 내 타입 선언 제거 및 import 구조 정리